### PR TITLE
feat(ui): add search filters and empty state

### DIFF
--- a/apps/ui/src/leaflet.d.ts
+++ b/apps/ui/src/leaflet.d.ts
@@ -1,0 +1,1 @@
+declare module 'leaflet';

--- a/apps/ui/src/lib/components/Filters.svelte
+++ b/apps/ui/src/lib/components/Filters.svelte
@@ -1,48 +1,70 @@
 <script lang="ts">
-  import { page } from "$app/stores";
-  // current query params
-  $: q = $page.url.searchParams.get("q") ?? "";
-  $: cat = $page.url.searchParams.get("cat") ?? "";
-  $: when = $page.url.searchParams.get("when") ?? "";
+	import { page } from '$app/stores';
+	// current query params
+	$: q = $page.url.searchParams.get('q') ?? '';
+	$: cat = $page.url.searchParams.get('cat') ?? '';
+	$: when = $page.url.searchParams.get('when') ?? '';
 
-  function link(params: Record<string,string|number|undefined>) {
-    const sp = new URLSearchParams($page.url.searchParams);
-    for (const [k,v] of Object.entries(params)) {
-      if (v === undefined || v === "") sp.delete(k); else sp.set(k,String(v));
-    }
-    sp.delete("page"); // reset paging
-    return `/?${sp.toString()}`;
-  }
+	function link(params: Record<string, string | number | undefined>) {
+		const sp = new URLSearchParams($page.url.searchParams);
+		for (const [k, v] of Object.entries(params)) {
+			if (v === undefined || v === '') sp.delete(k);
+			else sp.set(k, String(v));
+		}
+		sp.delete('page'); // reset paging
+		return `/?${sp.toString()}`;
+	}
 
-  const cats = [
-    { id: "music", label: "Glazba" },
-    { id: "sport", label: "Sport" },
-    { id: "theatre", label: "Kazalište" },
-    { id: "festival", label: "Festivali" }
-  ];
+	const cats = [
+		{ id: 'music', label: 'Glazba' },
+		{ id: 'sport', label: 'Sport' },
+		{ id: 'theatre', label: 'Kazalište' },
+		{ id: 'festival', label: 'Festivali' }
+	];
 </script>
+
+<!-- Search form -->
+<form method="get" class="mb-4 flex w-full items-center gap-2">
+	<input type="hidden" name="cat" value={cat} />
+	<input type="hidden" name="when" value={when} />
+	<input
+		type="text"
+		name="q"
+		placeholder="Pretraži događaje..."
+		value={q}
+		class="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none"
+	/>
+	<button
+		type="submit"
+		class="rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground hover:bg-primary/90"
+		>Traži</button
+	>
+</form>
 
 <!-- When tabs -->
 <div class="mb-4 flex flex-wrap gap-2">
-  {#each [
-    { id: "", label: "Sve" },
-    { id: "today", label: "Danas" },
-    { id: "weekend", label: "Vikend" },
-    { id: "next-week", label: "Sljedeći tjedan" }
-  ] as w}
-    <a href={link({ when: w.id })}
-       class="rounded-full border px-3 py-1.5 text-sm transition {when===w.id ? 'border-cyan-400/40 bg-cyan-400/10 text-cyan-200' : 'border-slate-700 bg-slate-900/40 text-slate-300 hover:border-slate-600'}">
-      {w.label}
-    </a>
-  {/each}
+	{#each [{ id: '', label: 'Sve' }, { id: 'today', label: 'Danas' }, { id: 'weekend', label: 'Vikend' }, { id: 'next-week', label: 'Sljedeći tjedan' }] as w}
+		<a
+			href={link({ when: w.id })}
+			class="rounded-full border px-3 py-1.5 text-sm transition {when === w.id
+				? 'border-cyan-400/40 bg-cyan-400/10 text-cyan-200'
+				: 'border-slate-700 bg-slate-900/40 text-slate-300 hover:border-slate-600'}"
+		>
+			{w.label}
+		</a>
+	{/each}
 </div>
 
 <!-- Category chips -->
 <div class="mb-4 flex flex-wrap gap-2">
-  {#each cats as c}
-    <a href={link({ cat: cat===c.id ? '' : c.id })}
-       class="rounded-full border px-3 py-1 text-xs transition {cat===c.id ? 'border-emerald-400/40 bg-emerald-400/10 text-emerald-200' : 'border-slate-700 bg-slate-900/40 text-slate-300 hover:border-slate-600'}">
-      {c.label}
-    </a>
-  {/each}
+	{#each cats as c}
+		<a
+			href={link({ cat: cat === c.id ? '' : c.id })}
+			class="rounded-full border px-3 py-1 text-xs transition {cat === c.id
+				? 'border-emerald-400/40 bg-emerald-400/10 text-emerald-200'
+				: 'border-slate-700 bg-slate-900/40 text-slate-300 hover:border-slate-600'}"
+		>
+			{c.label}
+		</a>
+	{/each}
 </div>

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
-  import EventCard from "$lib/components/EventCard.svelte";
-  export let data: any;
-  const items = data?.items ?? [];
+	import EventCard from '$lib/components/EventCard.svelte';
+	import Filters from '$lib/components/Filters.svelte';
+	export let data: any;
+	const items = data?.items ?? [];
 </script>
 
-<div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-  {#each items as e}
-    <EventCard event={e} />
-  {/each}
+<Filters />
+
+{#if items.length === 0}
+	<p class="text-center text-muted-foreground">Trenutno nema događaja.</p>
+{/if}
+
+<div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+	{#each items as e}
+		<EventCard event={e} />
+	{/each}
 </div>


### PR DESCRIPTION
## Summary
- add search bar to filters and show empty-state messaging
- wire filters into the home page for better event discovery
- declare Leaflet module so `svelte-check` passes

## Testing
- `cd apps/ui && pnpm lint`
- `cd apps/ui && pnpm check`

------
https://chatgpt.com/codex/tasks/task_e_68a5b93e72048324a021713c6c0bf908